### PR TITLE
chore(ci): add GitHub Actions workflow for documentation deployment

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,25 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - uses: actions/cache@v2
+        with:
+          key: ${{ github.ref }}
+          path: .cache
+      - run: pip install mkdocs-material
+      - run: pip install pillow cairosvg
+      - run: pip install mkdocs
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of project documentation. The workflow is triggered on pushes to the `main` branch and uses `mkdocs` for generating and deploying the documentation.

### New GitHub Actions Workflow:

* `.github/workflows/documentation.yml`: Added a `Deploy Documentation` workflow that:
  - Runs on `ubuntu-latest`.
  - Installs necessary Python dependencies (`mkdocs-material`, `pillow`, `cairosvg`, and `mkdocs`).
  - Deploys the documentation using `mkdocs gh-deploy --force`.